### PR TITLE
Add support for extra configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Optional environment variables:
 | KEEP_TEST_DB | 1 | Do not drop the database after test execution (useful for manual inspection) | 0 |
 | TEST_DB_NAME_OVERRIDE | _String_ | Define a custom name for the testing database created on the instance. Setting this to `foo` will result in the database `test_env_foo` being created | random 5-digit integer |
 | CUSTOM_STEPS_DIR | /path/to/dir | Path to a directory where custom step definitions are stored | |
+| SQUCUMBER_OPTIONS_EXTRA | `--strict` | Specify extra configuration options to the run command | |
 
 
 ## Available Steps

--- a/lib/squcumber-postgres/rake/task.rb
+++ b/lib/squcumber-postgres/rake/task.rb
@@ -26,7 +26,8 @@ module Squcumber
                   output_file = ENV['CUSTOM_OUTPUT_NAME'] ? ENV['CUSTOM_OUTPUT_NAME'] : feature_name.gsub('/', '_')
                   output_path = output_dir + '/' + output_file
                   output_opts = "--format html --out #{output_path}.html --format json --out #{output_path}.json"
-                  t.cucumber_opts = "#{feature}#{line_number} --format pretty #{output_opts} --require #{File.dirname(__FILE__)}/../support --require #{File.dirname(__FILE__)}/../step_definitions #{ENV['CUSTOM_STEPS_DIR'] ? '--require ' + ENV['CUSTOM_STEPS_DIR'] : ''}"
+                  extra_config = ENV['SQUCUMBER_OPTIONS_EXTRA']
+                  t.cucumber_opts = "#{feature}#{line_number} --format pretty #{output_opts} --require #{File.dirname(__FILE__)}/../support --require #{File.dirname(__FILE__)}/../step_definitions #{ENV['CUSTOM_STEPS_DIR'] ? '--require ' + ENV['CUSTOM_STEPS_DIR'] : ''} #{extra_config}"
                 end
                 ::Rake::Task[cucumber_task_name].execute
               end
@@ -47,7 +48,8 @@ module Squcumber
                   output_file = ENV['CUSTOM_OUTPUT_NAME'] ? ENV['CUSTOM_OUTPUT_NAME'] : feature_name.gsub('/', '_')
                   output_path = output_dir + '/' + output_file
                   output_opts = "--format html --out #{output_path}.html --format json --out #{output_path}.json"
-                  t.cucumber_opts = "#{feature} --format pretty #{output_opts} --require #{File.dirname(__FILE__)}/../support --require #{File.dirname(__FILE__)}/../step_definitions #{ENV['CUSTOM_STEPS_DIR'] ? '--require ' + ENV['CUSTOM_STEPS_DIR'] : ''}"
+                  extra_config = ENV['SQUCUMBER_OPTIONS_EXTRA']
+                  t.cucumber_opts = "#{feature} --format pretty #{output_opts} --require #{File.dirname(__FILE__)}/../support --require #{File.dirname(__FILE__)}/../step_definitions #{ENV['CUSTOM_STEPS_DIR'] ? '--require ' + ENV['CUSTOM_STEPS_DIR'] : ''} #{extra_config}"
                 end
                 ::Rake::Task[cucumber_task_name].execute
               end


### PR DESCRIPTION
This adds an environment variable SQUCUMBER_OPTIONS_EXTRA that, if set,
allows to add extra configuration parameters to the underlying Cucumber
run command. It is appended to the existing configuration. This is
useful for adding e.g. `--strict` to let tests fail if steps are
undefined or for specifying additional output formats and directories.