### PR TITLE
Add sophisticated date matchers

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -23,23 +23,127 @@ module MatcherHelpers
   def convert_mock_values(mock_data)
     mock_data.map do |entry|
       entry.each do |key, value|
-        entry[key] = case value
-          when /today/
-            Date.today.to_s
-          when /yesterday/
-            Date.today.prev_day.to_s
-          when /\s*\d+\s+month(s)?\s+ago\s*/
-            number_of_months = value.match(/\d+/)[0].to_i
-            timetravel(Date.today, number_of_months, :prev_month).to_s
-          when /\s*\d+\s+day(s)?\s+ago\s*/
-            number_of_days = value.match(/\d+/)[0].to_i
-            timetravel(Date.today, number_of_days, :prev_day).to_s
-          else
-            value
-        end
+        # Examples of valid values; all examples assume that today is 30th July 2017
+        #
+        #    1 month ago
+        #    => '2017-06-30'
+        #
+        #    40 days ago (as month)
+        #    => '6'
+        #
+        #    2 years ago (as year)
+        #    => '2015'
+        #
+        #    beginning of last month
+        #    => '2017-06-01'
+        #
+        #    end of last year
+        #    => '2016-12-31'
+        #
+        #    today (as custom '%Y-%m')
+        #    => '2017-07'
+        #
+        entry[key] = convert_mock_value(value)
       end
+    end
+  end
+
+  def convert_mock_value(value)
+    value_parser_regexp = /\s*((?<modifier>(beginning|end))\s+of\s+(?<modifier_base>day|month|year))?\s*(?<placeholder>[^\(\)]+)\s*(\(as (?<format>day|month|year|(custom '[^']+'))\))?\s*/
+
+    parsed_value = value.match(value_parser_regexp)
+    placeholder = parsed_value[:placeholder]
+    format = parsed_value[:format]
+    modifier = parsed_value[:modifier]
+    modifier_base = parsed_value[:modifier_base]
+
+    new_value = case placeholder
+      when /today/
+        Date.today
+      when /yesterday/
+        timetravel(Date.today, 1, :prev_day)
+      when /tomorrow/
+        timetravel(Date.today, 1, :next_day)
+      when /last month/
+        timetravel(Date.today, 1, :prev_month)
+      when /next month/
+        timetravel(Date.today, 1, :next_month)
+      when /last year/
+        timetravel(Date.today, 1, :prev_year)
+      when /next year/
+        timetravel(Date.today, 1, :next_year)
+      when /\s*\d+\s+month(s)?\s+ago\s*?/
+        number_of_months = value.match(/\d+/)[0].to_i
+        timetravel(Date.today, number_of_months, :prev_month)
+      when /\s*\d+\s+day(s)?\s+ago\s*/
+        number_of_days = value.match(/\d+/)[0].to_i
+        timetravel(Date.today, number_of_days, :prev_day)
+      when /\s*\d+\s+year(s)?\s+ago\s*/
+        number_of_years = value.match(/\d+/)[0].to_i
+        timetravel(Date.today, number_of_years, :prev_year)
+      when /\s*\d+\s+month(s)?\s+from now\s*?/
+        number_of_months = value.match(/\d+/)[0].to_i
+        timetravel(Date.today, number_of_months, :next_month)
+      when /\s*\d+\s+day(s)?\s+from now\s*/
+        number_of_days = value.match(/\d+/)[0].to_i
+        timetravel(Date.today, number_of_days, :next_day)
+      when /\s*\d+\s+year(s)?\s+from now\s*/
+        number_of_years = value.match(/\d+/)[0].to_i
+        timetravel(Date.today, number_of_years, :next_year)
+      else
+        placeholder
+    end
+
+    if new_value.is_a?(Date)
+      modified_new_value = case modifier
+        when nil
+          new_value
+        when 'beginning'
+          case modifier_base
+            when 'day'
+              new_value
+            when 'month'
+              Date.new(new_value.year, new_value.month, 1)
+            when 'year'
+              Date.new(new_value.year, 1, 1)
+            else
+              raise "Invalid date modifier provided: #{modifier} #{modifier_base}"
+          end
+        when 'end'
+          case modifier_base
+            when 'day'
+              new_value
+            when 'month'
+              Date.new(new_value.next_month.year, new_value.next_month.month, 1).prev_day
+            when 'year'
+              Date.new(new_value.next_year.year, 1, 1).prev_day
+            else
+              raise "Invalid date modifier provided: #{modifier} #{modifier_base}"
+          end
+        else
+          raise "Invalid date modifier provided: #{modifier} #{modifier_base}"
+      end
+
+      formatted_new_value = case format
+        when nil
+          puts "NO FORMAT"
+          modified_new_value.to_s
+        when 'day', 'month', 'year'
+          modified_new_value.send(format.to_sym)
+        when /custom '[^']+'/
+          parsed_format = format.match(/custom '(?<format_string>[^']+)'/)
+          modified_new_value.strftime(parsed_format[:format_string])
+        else
+          raise "Invalid date format provided: #{format}"
+      end
+
+      formatted_new_value
+    else
+      new_value
     end
   end
 end
 
-World(MatcherHelpers)
+if defined?(World)
+  World(MatcherHelpers)
+end

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -1,0 +1,113 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/squcumber-postgres/support/matchers'
+
+module Squcumber
+  describe 'MatcherHelpers' do
+    let(:dummy_class) { Class.new { include MatcherHelpers } }
+
+    before(:each) do
+      allow(Date).to receive(:today).and_return Date.new(2017, 7, 15)
+    end
+
+    describe '#convert_mock_values' do
+      context 'with day placeholders' do
+        it 'sets today' do
+          expect(dummy_class.new.convert_mock_value('today')).to eql('2017-07-15')
+        end
+        it 'sets tomorrow' do
+          expect(dummy_class.new.convert_mock_value('tomorrow')).to eql('2017-07-16')
+        end
+        it 'sets yesterday' do
+          expect(dummy_class.new.convert_mock_value('yesterday')).to eql('2017-07-14')
+        end
+        it 'travels into the past' do
+          expect(dummy_class.new.convert_mock_value('10 days ago')).to eql('2017-07-05')
+        end
+        it 'travels into the future' do
+          expect(dummy_class.new.convert_mock_value('30 days from now')).to eql('2017-08-14')
+        end
+        it 'converts to day' do
+          expect(dummy_class.new.convert_mock_value('10 days from now (as day)')).to eql(25)
+        end
+        it 'converts to month' do
+          expect(dummy_class.new.convert_mock_value('30 days from now (as month)')).to eql(8)
+        end
+        it 'converts to year' do
+          expect(dummy_class.new.convert_mock_value('30 days from now (as year)')).to eql(2017)
+        end
+        it 'sets beginning of day' do
+          expect(dummy_class.new.convert_mock_value('beginning of day 10 days from now')).to eql('2017-07-25')
+        end
+        it 'sets end of day' do
+          expect(dummy_class.new.convert_mock_value('end of day 10 days from now')).to eql('2017-07-25')
+        end
+      end
+
+      context 'with month placeholders' do
+        it 'sets last month' do
+          expect(dummy_class.new.convert_mock_value('last month')).to eql('2017-06-15')
+        end
+        it 'sets next month' do
+          expect(dummy_class.new.convert_mock_value('next month')).to eql('2017-08-15')
+        end
+        it 'travels into the past' do
+          expect(dummy_class.new.convert_mock_value('10 months ago')).to eql('2016-09-15')
+        end
+        it 'travels into the future' do
+          expect(dummy_class.new.convert_mock_value('10 months from now')).to eql('2018-05-15')
+        end
+        it 'converts to day' do
+          expect(dummy_class.new.convert_mock_value('10 months from now (as day)')).to eql(15)
+        end
+        it 'converts to month' do
+          expect(dummy_class.new.convert_mock_value('10 months from now (as month)')).to eql(5)
+        end
+        it 'converts to year' do
+          expect(dummy_class.new.convert_mock_value('10 months from now (as year)')).to eql(2018)
+        end
+        it 'sets beginning of month' do
+          expect(dummy_class.new.convert_mock_value('beginning of month 10 months from now')).to eql('2018-05-01')
+        end
+        it 'sets end of month' do
+          expect(dummy_class.new.convert_mock_value('end of month 10 months from now')).to eql('2018-05-31')
+        end
+      end
+
+      context 'with year placeholders' do
+        it 'sets last year' do
+          expect(dummy_class.new.convert_mock_value('last year')).to eql('2016-07-15')
+        end
+        it 'sets next year' do
+          expect(dummy_class.new.convert_mock_value('next year')).to eql('2018-07-15')
+        end
+        it 'travels into the past' do
+          expect(dummy_class.new.convert_mock_value('10 years ago')).to eql('2007-07-15')
+        end
+        it 'travels into the future' do
+          expect(dummy_class.new.convert_mock_value('10 years from now')).to eql('2027-07-15')
+        end
+        it 'converts to day' do
+          expect(dummy_class.new.convert_mock_value('10 years from now (as day)')).to eql(15)
+        end
+        it 'converts to month' do
+          expect(dummy_class.new.convert_mock_value('10 years from now (as month)')).to eql(7)
+        end
+        it 'converts to year' do
+          expect(dummy_class.new.convert_mock_value('10 years from now (as year)')).to eql(2027)
+        end
+        it 'sets beginning of year' do
+          expect(dummy_class.new.convert_mock_value('beginning of year 10 months from now')).to eql('2018-01-01')
+        end
+        it 'sets end of year' do
+          expect(dummy_class.new.convert_mock_value('end of year 10 months from now')).to eql('2018-12-31')
+        end
+      end
+
+      context 'with custom format' do
+        it 'sets the date format' do
+          expect(dummy_class.new.convert_mock_value('today (as custom \'%Y/%m/%d\')')).to eql('2017/07/15')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds date matchers with the following modifiers:
 - `beginning/end` `of` `day/month/year`
 - `X` `days/months/years` `ago/from now`
 - `(as` `day/month/year/custom` `)`

Which can be combined freely to e.g.:
 - `beginning of month 7 years from now (as day)`
 - `end of year 10 months ago (as custom '%Y/%m/%d')`

The custom formatter uses Ruby formatting:
https://apidock.com/ruby/DateTime/strftime