### PR TITLE
Release v0.0.7

### DIFF
--- a/lib/squcumber-postgres/step_definitions/common_steps.rb
+++ b/lib/squcumber-postgres/step_definitions/common_steps.rb
@@ -101,6 +101,13 @@ When(/^the resulting table "?([^\s"]*)"? is queried(?:, ordered by "?([^"]*)"?)?
   @result = TESTING_DATABASE.query("select * from #{table} #{sort_statement};").map { |e| e }
 end
 
+When(/^the result is ordered by "?([^"]+)"?/) do |sort_columns_string|
+  sort_columns = sort_columns_string.split(',').map { |sort_column| sort_column.strip }
+  @result = @result.sort_by do |row|
+    sort_columns.map { |sort_column| row[sort_column] }
+  end
+end
+
 Then(/^the result( with date placeholders)? starts with.*$/) do |placeholder, data|
   actual = @result[0..(data.hashes.length - 1)] || []
   expected = data.hashes || []

--- a/lib/squcumber-postgres/step_definitions/common_steps.rb
+++ b/lib/squcumber-postgres/step_definitions/common_steps.rb
@@ -82,13 +82,17 @@ end
 
 When(/^the given SQL files are executed$/) do
   silence_streams(STDERR) do
-    @sql_files_to_execute.each { |file| TESTING_DATABASE.exec_file(file) }
+    @sql_files_to_execute.each do |file|
+      # This overwrites the result if multiple files are executed
+      @result = TESTING_DATABASE.exec_file(file)
+    end
   end
 end
 
 When(/^the SQL file "?([^\s"]+)"? is executed/) do |file|
   silence_streams(STDERR) do
-    TESTING_DATABASE.exec_file("#{@sql_file_path}/#{file}")
+    # This overwrites the result if multiple files are executed
+    @result = TESTING_DATABASE.exec_file("#{@sql_file_path}/#{file}")
   end
 end
 

--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -34,10 +34,10 @@ module MatcherHelpers
         #    2 years ago (as year)
         #    => '2015'
         #
-        #    beginning of last month
+        #    beginning of month last month
         #    => '2017-06-01'
         #
-        #    end of last year
+        #    end of month last year
         #    => '2016-12-31'
         #
         #    today (as custom '%Y-%m')

--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -126,7 +126,6 @@ module MatcherHelpers
 
       formatted_new_value = case format
         when nil
-          puts "NO FORMAT"
           modified_new_value.to_s
         when 'day', 'month', 'year'
           modified_new_value.send(format.to_sym)
@@ -137,9 +136,9 @@ module MatcherHelpers
           raise "Invalid date format provided: #{format}"
       end
 
-      formatted_new_value
+      formatted_new_value.to_s
     else
-      new_value
+      new_value.to_s
     end
   end
 end

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -27,13 +27,13 @@ module Squcumber
           expect(dummy_class.new.convert_mock_value('30 days from now')).to eql('2017-08-14')
         end
         it 'converts to day' do
-          expect(dummy_class.new.convert_mock_value('10 days from now (as day)')).to eql(25)
+          expect(dummy_class.new.convert_mock_value('10 days from now (as day)')).to eql('25')
         end
         it 'converts to month' do
-          expect(dummy_class.new.convert_mock_value('30 days from now (as month)')).to eql(8)
+          expect(dummy_class.new.convert_mock_value('30 days from now (as month)')).to eql('8')
         end
         it 'converts to year' do
-          expect(dummy_class.new.convert_mock_value('30 days from now (as year)')).to eql(2017)
+          expect(dummy_class.new.convert_mock_value('30 days from now (as year)')).to eql('2017')
         end
         it 'sets beginning of day' do
           expect(dummy_class.new.convert_mock_value('beginning of day 10 days from now')).to eql('2017-07-25')
@@ -57,13 +57,13 @@ module Squcumber
           expect(dummy_class.new.convert_mock_value('10 months from now')).to eql('2018-05-15')
         end
         it 'converts to day' do
-          expect(dummy_class.new.convert_mock_value('10 months from now (as day)')).to eql(15)
+          expect(dummy_class.new.convert_mock_value('10 months from now (as day)')).to eql('15')
         end
         it 'converts to month' do
-          expect(dummy_class.new.convert_mock_value('10 months from now (as month)')).to eql(5)
+          expect(dummy_class.new.convert_mock_value('10 months from now (as month)')).to eql('5')
         end
         it 'converts to year' do
-          expect(dummy_class.new.convert_mock_value('10 months from now (as year)')).to eql(2018)
+          expect(dummy_class.new.convert_mock_value('10 months from now (as year)')).to eql('2018')
         end
         it 'sets beginning of month' do
           expect(dummy_class.new.convert_mock_value('beginning of month 10 months from now')).to eql('2018-05-01')
@@ -87,13 +87,13 @@ module Squcumber
           expect(dummy_class.new.convert_mock_value('10 years from now')).to eql('2027-07-15')
         end
         it 'converts to day' do
-          expect(dummy_class.new.convert_mock_value('10 years from now (as day)')).to eql(15)
+          expect(dummy_class.new.convert_mock_value('10 years from now (as day)')).to eql('15')
         end
         it 'converts to month' do
-          expect(dummy_class.new.convert_mock_value('10 years from now (as month)')).to eql(7)
+          expect(dummy_class.new.convert_mock_value('10 years from now (as month)')).to eql('7')
         end
         it 'converts to year' do
-          expect(dummy_class.new.convert_mock_value('10 years from now (as year)')).to eql(2027)
+          expect(dummy_class.new.convert_mock_value('10 years from now (as year)')).to eql('2027')
         end
         it 'sets beginning of year' do
           expect(dummy_class.new.convert_mock_value('beginning of year 10 months from now')).to eql('2018-01-01')

--- a/squcumber-postgres.gemspec
+++ b/squcumber-postgres.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name               = 'squcumber-postgres'
-  s.version            = '0.0.6'
+  s.version            = '0.0.7'
   s.default_executable = 'squcumber-postgres'
 
   s.licenses = ['MIT']
   s.required_ruby_version = '>= 2.0'
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Stefanie Grunwald']
-  s.date = %q{2018-09-23}
+  s.date = %q{2018-09-24}
   s.email = %q{steffi@physics.org}
   s.files = [
     'Rakefile',


### PR DESCRIPTION
 * (ee62946) Change default to return query results
 * (ace9456) Fix typos in documentation
 * (b706292) Add step to support ordering of results
 * (ae2e8bc) Return placeholder matchers as strings

Fixes #2