### PR TITLE
Add monthTravel func to fix date issues with timetravel

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -19,6 +19,7 @@ module MatcherHelpers
   end
 
   def timetravel(date, i, method); i > 0 ? timetravel(date.send(method.to_sym), i - 1, method) : date; end
+  def monthtravel(date, i); i != 0 ? Date.new(date.year, date.month + i, -1) : date; end
 
   def convert_mock_values(mock_data)
     mock_data.map do |entry|
@@ -65,16 +66,16 @@ module MatcherHelpers
       when /tomorrow/
         timetravel(Date.today, 1, :next_day)
       when /last month/
-        timetravel(Date.today, 1, :prev_month)
+        monthtravel(Date.today, -1)
       when /next month/
-        timetravel(Date.today, 1, :next_month)
+        monthtravel(Date.today, 1)
       when /last year/
         timetravel(Date.today, 1, :prev_year)
       when /next year/
         timetravel(Date.today, 1, :next_year)
       when /\s*\d+\s+month(s)?\s+ago\s*?/
         number_of_months = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_months, :prev_month)
+        monthtravel(Date.today, number_of_months * -1)
       when /\s*\d+\s+day(s)?\s+ago\s*/
         number_of_days = value.match(/\d+/)[0].to_i
         timetravel(Date.today, number_of_days, :prev_day)


### PR DESCRIPTION
This PR suggest a function monthTravel to fix the bug with timetravel:
```
irb(main):003:0> Date.today
=> #<Date: 2018-10-31 ((2458423j,0s,0n),+0s,2299161j)>
irb(main):008:0> timetravel(Date.today, 1, :next_month)
=> #<Date: 2018-11-30 ((2458453j,0s,0n),+0s,2299161j)>
irb(main):009:0> timetravel(Date.today, 1, :prev_month)
=> #<Date: 2018-09-30 ((2458392j,0s,0n),+0s,2299161j)>
irb(main):010:0> timetravel(Date.today, 2, :prev_month)
=> #<Date: 2018-08-30 ((2458361j,0s,0n),+0s,2299161j)>
irb(main):011:0> timetravel(Date.today, 3, :prev_month)
=> #<Date: 2018-07-30 ((2458330j,0s,0n),+0s,2299161j)>
irb(main):012:0> timetravel(Date.today, 1, :next_month)
=> #<Date: 2018-11-30 ((2458453j,0s,0n),+0s,2299161j)>
irb(main):013:0> timetravel(Date.today, 2, :next_month)
=> #<Date: 2018-12-30 ((2458483j,0s,0n),+0s,2299161j)>
```

Fix:
````
def monthTravel(date, i); i > 0 ? date.next_month(i) : i < 0 ? date.prev_month(i * -1) : date; end
irb(main):008:0> Date.today
=> #<Date: 2018-10-31 ((2458423j,0s,0n),+0s,2299161j)>
irb(main):009:0> monthTravel(Date.today, -1)
=> #<Date: 2018-09-30 ((2458392j,0s,0n),+0s,2299161j)>
irb(main):010:0> monthTravel(Date.today, -2)
=> #<Date: 2018-08-31 ((2458362j,0s,0n),+0s,2299161j)>
irb(main):011:0> monthTravel(Date.today, -3)
=> #<Date: 2018-07-31 ((2458331j,0s,0n),+0s,2299161j)>
irb(main):012:0> monthTravel(Date.today, 1)
=> #<Date: 2018-11-30 ((2458453j,0s,0n),+0s,2299161j)>
irb(main):013:0> monthTravel(Date.today, 2)
=> #<Date: 2018-12-31 ((2458484j,0s,0n),+0s,2299161j)>
irb(main):014:0> monthTravel(Date.today, 3)
=> #<Date: 2019-01-31 ((2458515j,0s,0n),+0s,2299161j)>
irb(main):015:0> monthTravel(Date.today, 4)
=> #<Date: 2019-02-28 ((2458543j,0s,0n),+0s,2299161j)>
``` 


