### PR TITLE
Keep raw value if it has not been parsed

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -138,7 +138,7 @@ module MatcherHelpers
 
       formatted_new_value.to_s
     else
-      new_value.to_s
+      value
     end
   end
 end


### PR DESCRIPTION
Whenever a value with parentheses would be encountered, the match groups
would be removed from the resulting string. This does not make sense as
the only case we're interested in a parsed value is when we're dealing
with date placeholders. This commit fixes the issue by returning the
original value if no date conversion has taken place.

Fixes #13