### PR TITLE
Fix multi-step jump for months of different length

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -18,8 +18,6 @@ module MatcherHelpers
     end
   end
 
-  def timetravel(date, i, method); i > 0 ? timetravel(date.send(method.to_sym), i - 1, method) : date; end
-
   def convert_mock_values(mock_data)
     mock_data.map do |entry|
       entry.each do |key, value|
@@ -61,35 +59,35 @@ module MatcherHelpers
       when /today/
         Date.today
       when /yesterday/
-        timetravel(Date.today, 1, :prev_day)
+        Date.today.prev_day
       when /tomorrow/
-        timetravel(Date.today, 1, :next_day)
+        Date.today.next_day
       when /last month/
-        timetravel(Date.today, 1, :prev_month)
+        Date.today.prev_month
       when /next month/
-        timetravel(Date.today, 1, :next_month)
+        Date.today.next_month
       when /last year/
-        timetravel(Date.today, 1, :prev_year)
+        Date.today.prev_year
       when /next year/
-        timetravel(Date.today, 1, :next_year)
+        Date.today.next_year
       when /\s*\d+\s+month(s)?\s+ago\s*?/
         number_of_months = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_months, :prev_month)
+        Date.today.prev_month(number_of_months)
       when /\s*\d+\s+day(s)?\s+ago\s*/
         number_of_days = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_days, :prev_day)
+        Date.today.prev_day(number_of_days)
       when /\s*\d+\s+year(s)?\s+ago\s*/
         number_of_years = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_years, :prev_year)
+        Date.today.prev_year(number_of_years)
       when /\s*\d+\s+month(s)?\s+from now\s*?/
         number_of_months = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_months, :next_month)
+        Date.today.next_month(number_of_months)
       when /\s*\d+\s+day(s)?\s+from now\s*/
         number_of_days = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_days, :next_day)
+        Date.today.next_day(number_of_days)
       when /\s*\d+\s+year(s)?\s+from now\s*/
         number_of_years = value.match(/\d+/)[0].to_i
-        timetravel(Date.today, number_of_years, :next_year)
+        Date.today.next_year(number_of_years)
       else
         placeholder
     end

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -44,6 +44,36 @@ module Squcumber
       end
 
       context 'with month placeholders' do
+        context 'during a leap year' do
+          it 'sets last month' do
+            allow(Date).to receive(:today).and_return Date.new(2019, 3, 29)
+            expect(dummy_class.new.convert_mock_value('last month')).to eql('2019-02-28')
+          end
+          it 'sets next month' do
+            allow(Date).to receive(:today).and_return Date.new(2019, 1, 29)
+            expect(dummy_class.new.convert_mock_value('next month')).to eql('2019-02-28')
+          end
+        end
+
+        context 'when the length of months differ' do
+          it 'travels into the past and keeps the day' do
+            allow(Date).to receive(:today).and_return Date.new(2019, 3, 31)
+            expect(dummy_class.new.convert_mock_value('2 month ago')).to eql('2019-01-31')
+          end
+          it 'travels into the future and keeps the day' do
+            allow(Date).to receive(:today).and_return Date.new(2019, 1, 31)
+            expect(dummy_class.new.convert_mock_value('2 months from now')).to eql('2019-03-31')
+          end
+          it 'sets beginning of month' do
+            allow(Date).to receive(:today).and_return Date.new(2019, 1, 31)
+            expect(dummy_class.new.convert_mock_value('beginning of month 9 months from now')).to eql('2019-10-01')
+          end
+          it 'sets end of month' do
+            allow(Date).to receive(:today).and_return Date.new(2019, 1, 31)
+            expect(dummy_class.new.convert_mock_value('end of month 9 months from now')).to eql('2019-10-31')
+          end
+        end
+
         it 'sets last month' do
           expect(dummy_class.new.convert_mock_value('last month')).to eql('2017-06-15')
         end


### PR DESCRIPTION
Whenever we'd travel more than one month into the future or into the
past in a test fixture, the day of month would end up being that of the
shortest month in between start and end month. For example, if the
current date was '2019-03-29', then jumping two months back would yield
'2019-01-28' instead of '2019-01-29' because February only has 28 days
in 2019. This would lead to unexpected results in test fixtures.

This commit fixes the issue by removing the timetravel() method and
replacing it with native calls to Ruby's :next_month or :prev_month
which, surprisingly, can take arguments, e.g. :next_month(2) to jump two
months forward, rendering the timetravel() method obsolete.