### PR TITLE
Fuzzy match today and yesterday

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -6,6 +6,10 @@ module MatcherHelpers
       actual.match(/#{Regexp.quote((Date.today - 1).to_s)}/)
     elsif expected.eql?('any_date')
       actual.match(/^\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}$/)
+    elsif expected.eql?('sometime today')
+      actual.match(/^#{Regexp.quote(Date.today.to_s)} \d{2}:\d{2}:\d{2}$/)
+    elsif expected.eql?('sometime yesterday')
+      actual.match(/^#{Regexp.quote((Date.today - 1).to_s)} \d{2}:\d{2}:\d{2}$/)
     elsif expected.eql?('any_string')
       true if actual.is_a?(String) or actual.nil?
     elsif expected.eql?('false') or expected.eql?('true')


### PR DESCRIPTION
In case of e.g. using `now()` or `current_timestamp()` in the query, it's
hard to determine the exact hour, minute and seconds of execution for
the comparison. In these cases, using a fuzzy matcher such as "sometime
today" should be enough to ensure that the query works as designed,
without adding too much overhead for e.g. mocking out core functions of
the database.

This PR adds two additional matchers "sometime today" and "sometime
yesterday". "sometime today" would match anything starting with the current
date and effectively ignore the timestamp portion.