### PR TITLE
Raise error for unknown column names

### DIFF
--- a/lib/squcumber-postgres/step_definitions/common_steps.rb
+++ b/lib/squcumber-postgres/step_definitions/common_steps.rb
@@ -113,6 +113,8 @@ Then(/^the result( with date placeholders)? starts with.*$/) do |placeholder, da
   expected = data.hashes || []
   expected = convert_mock_values(expected) if placeholder
 
+  sanity_check_result(actual, expected)
+
   expected.each_with_index do |hash, i|
     raise("Does not start with expected result, got:\n#{format_error(data, actual)}") unless actual[i].all? do |key, value|
       values_match(value, hash[key]) # actual,expected
@@ -125,10 +127,12 @@ Then(/^the result( with date placeholders)? includes.*$/) do |placeholder, data|
   expected = data.hashes || []
   expected = convert_mock_values(expected) if placeholder
 
+  sanity_check_result(actual, expected)
+
   expected.each do |hash|
     raise("Result is not included, got:\n#{format_error(data, actual)}") unless actual.any? do |row|
       row.all? do |key, value|
-        values_match(value, hash[key]) # actual,expected
+        values_match(value, hash[key]) # actual, expected
       end
     end
   end
@@ -138,6 +142,8 @@ Then(/^the result( with date placeholders)? does not include.*$/) do |placeholde
   actual = @result || []
   expected = data.hashes || []
   expected = convert_mock_values(expected) if placeholder
+
+  sanity_check_result(actual, expected)
 
   expected.each do |hash|
     raise("Result is included, got:\n#{format_error(data, actual)}") if actual.any? do |row|
@@ -152,6 +158,8 @@ Then(/^the result( with date placeholders)? exactly matches.*$/) do |placeholder
   actual = @result || []
   expected = data.hashes || []
   expected = convert_mock_values(expected) if placeholder
+
+  sanity_check_result(actual, expected)
 
   raise("Does not match exactly, got:\n#{format_error(data, actual)}") if actual.length != expected.length
 

--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -1,4 +1,15 @@
 module MatcherHelpers
+  def sanity_check_result(actual, expected)
+    raise("The returned result is empty") if actual.empty?
+    raise("No data provided for comparison") if expected.empty?
+
+    expected[0].keys.each do |expected_key|
+      unless actual[0].keys.include?(expected_key)
+        raise("Column name '#{expected_key}' does not exist in result.\nAvailable column names are #{actual[0].keys.join(', ')}")
+      end
+    end
+  end
+
   def values_match(actual, expected)
     if expected.eql?('today')
       actual.match(/#{Regexp.quote(Date.today.to_s)}/)


### PR DESCRIPTION
When specifying a non-existing column name in the expected result set,
this would be silently ignored. This would be confusing in case of typos
because they could lead to tests succeeding even in the face of errors.

This commit adds some additional checks in order to provide a more
meaningful error message when the returned result is empty, and to flag
typos immediately.

Fixes #18