### PR TITLE
Prevent system tables from being truncated

### DIFF
--- a/lib/squcumber-postgres/mock/database.rb
+++ b/lib/squcumber-postgres/mock/database.rb
@@ -36,7 +36,7 @@ module Squcumber
 
         def truncate_all_tables
           @testing_database
-            .exec("select schemaname || '.' || tablename as schema_and_table from pg_tables where tableowner = '#{ENV['DB_USER']}'")
+            .exec("select schemaname || '.' || tablename as schema_and_table from pg_tables where tableowner = '#{ENV['DB_USER']}' and schemaname not in ('pg_catalog', 'information_schema')")
             .map { |row| row['schema_and_table'] }
             .each { |schema_and_table| exec("truncate table #{schema_and_table}") }
         end

--- a/squcumber-postgres.gemspec
+++ b/squcumber-postgres.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name               = 'squcumber-postgres'
-  s.version            = '0.0.12'
+  s.version            = '0.0.13'
   s.default_executable = 'squcumber-postgres'
 
   s.licenses = ['MIT']
   s.required_ruby_version = '>= 2.0'
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Stefanie Grunwald']
-  s.date = %q{2019-08-27}
+  s.date = %q{2021-10-15}
   s.email = %q{steffi@physics.org}
   s.files = [
     'Rakefile',


### PR DESCRIPTION
This would manifest as a permission denied error whenever there are more
than two scenarios in a feature and the Postgres has only a single
database object.

From local inspection, only pg_catalog and information_schema show up in
this query, although it might be wise in the future to exclude all pg_
prefixed schemas.