### PR TITLE
Feature add minutes date placeholders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.0 as builder
+FROM ruby:2.5.0 as builder
 COPY ./lib lib
 COPY ./spec spec
 COPY ./Rakefile .
@@ -6,7 +6,7 @@ COPY ./Gemfile .
 COPY ./squcumber-postgres.gemspec .
 RUN gem build squcumber-postgres.gemspec
 
-FROM ruby:2.3.0
+FROM ruby:2.5.0
 ENV CUSTOM_STEPS_DIR /custom_step_definitions
 VOLUME /custom_step_definitions
 VOLUME /features

--- a/Dockerfile_tests
+++ b/Dockerfile_tests
@@ -1,4 +1,4 @@
-FROM ruby:2.3.0
+FROM ruby:2.5.0
 
 COPY ./squcumber-postgres.gemspec squcumber-postgres.gemspec
 COPY ./Gemfile Gemfile

--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -85,6 +85,12 @@ module MatcherHelpers
         Date.today.prev_year
       when /next year/
         Date.today.next_year
+      when /\s*\d+\s+minute(s)?\s+ago\s*?/
+        number_of_minutes = value.match(/\d+/)[0].to_i
+        DateTime.now - (number_of_minutes/24.0/60.0)
+      when /\s*\d+\s+hours(s)?\s+ago\s*?/
+        number_of_hours = value.match(/\d+/)[0].to_i
+        DateTime.now - (number_of_hours/24.0)
       when /\s*\d+\s+month(s)?\s+ago\s*?/
         number_of_months = value.match(/\d+/)[0].to_i
         Date.today.prev_month(number_of_months)
@@ -94,6 +100,12 @@ module MatcherHelpers
       when /\s*\d+\s+year(s)?\s+ago\s*/
         number_of_years = value.match(/\d+/)[0].to_i
         Date.today.prev_year(number_of_years)
+      when /\s*\d+\s+minute(s)?\s+from now\s*?/
+        number_of_minutes = value.match(/\d+/)[0].to_i
+        DateTime.now + (number_of_minutes/24.0/60.0)
+      when /\s*\d+\s+hours(s)?\s+from now\s*?/
+        number_of_hours = value.match(/\d+/)[0].to_i
+        DateTime.now + (number_of_hours/24.0)
       when /\s*\d+\s+month(s)?\s+from now\s*?/
         number_of_months = value.match(/\d+/)[0].to_i
         Date.today.next_month(number_of_months)

--- a/spec/squcumber-postgres/mock/database_spec.rb
+++ b/spec/squcumber-postgres/mock/database_spec.rb
@@ -182,7 +182,7 @@ module Squcumber::Postgres::Mock
       end
 
       it 'asks the testing database for currently existing tables in production schemas' do
-        expect(testing_database).to have_received(:exec).with(/^\s*select\s+schemaname\s+\|\|\s+'\.'\s+\|\|\s+tablename\s+as schema\_and\_table\s+from\s+pg_tables\s+where\s+tableowner\s*=\s*'some_user'\s*;?\s*$/)
+        expect(testing_database).to have_received(:exec).with(/^\s*select\s+schemaname\s+\|\|\s+'\.'\s+\|\|\s+tablename\s+as schema\_and\_table\s+from\s+pg_tables\s+where\s+tableowner\s*=\s*'some_user'\s+and\s+schemaname\s+not\s+in\s+\('pg_catalog',\s+'information_schema'\s*\)\s*;?\s*$/)
       end
 
       it 'truncates the returned tables in the testing database' do

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -7,6 +7,24 @@ module Squcumber
 
     before(:each) do
       allow(Date).to receive(:today).and_return Date.new(2017, 7, 15)
+      allow(DateTime).to receive(:now).and_return DateTime.new(2017, 7, 15, 10, 20, 30)
+    end
+
+    describe '#convert_mock_values' do
+      context 'with minute placeholders' do
+        it 'sets minutes in the future' do
+          expect(dummy_class.new.convert_mock_value('10 minutes from now')).to eql('2017-07-15T10:30:30+00:00')
+        end
+        it 'sets minutes in the past' do
+          expect(dummy_class.new.convert_mock_value('10 minutes ago')).to eql('2017-07-15T10:10:30+00:00')
+        end
+        it 'sets hours in the future' do
+          expect(dummy_class.new.convert_mock_value('9 hours from now')).to eql('2017-07-15T19:20:30+00:00')
+        end
+        it 'sets hours in the past' do
+          expect(dummy_class.new.convert_mock_value('9 hours ago')).to eql('2017-07-15T01:20:30+00:00')
+        end
+      end
     end
 
     describe '#convert_mock_values' do


### PR DESCRIPTION
Some kinds of tests require higher precision than `today` or `yesterday`. This PR adds support for the following placeholders:

```
X minutes ago
X minutes from now
X hours ago
X hours from now
```

All timestamps will be added in UTC, so `+00:00` encoded at the end.