### PR TITLE
Introduce null mapper as step

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -10,7 +10,7 @@ module MatcherHelpers
     end
   end
 
-  def values_match(actual, expected)
+  def values_match(actual, expected, null=nil)
     if expected.eql?('today')
       actual.match(/#{Regexp.quote(Date.today.to_s)}/)
     elsif expected.eql?('yesterday')
@@ -21,6 +21,8 @@ module MatcherHelpers
       actual.match(/^#{Regexp.quote(Date.today.to_s)} \d{2}:\d{2}:\d{2}$/)
     elsif expected.eql?('sometime yesterday')
       actual.match(/^#{Regexp.quote((Date.today - 1).to_s)} \d{2}:\d{2}:\d{2}$/)
+    elsif !null.nil? and !expected.nil?
+      expected.eql?(null) and actual.nil?
     elsif expected.eql?('any_string')
       true if actual.is_a?(String) or actual.nil?
     elsif expected.eql?('false') or expected.eql?('true')
@@ -30,6 +32,22 @@ module MatcherHelpers
       actual.eql?(expected)
     else  # we have not mocked this, so ignore it
       true
+    end
+  end
+
+  def convert_null_values(mock_data, null)
+    mock_data.map do |entry|
+      entry.each do |key, value|
+        entry[key] = convert_null_value(value)
+      end
+    end
+  end
+
+  def convert_null_value(value, null)
+    if null.nil?
+      value
+    elsif value.eql?(null)
+      nil
     end
   end
 

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -10,6 +10,53 @@ module Squcumber
       allow(DateTime).to receive(:now).and_return DateTime.new(2017, 7, 15, 10, 20, 30)
     end
 
+    describe '#convert_null_values' do
+      context 'when no mapping is defined' do
+        it 'leaves the original value as it is' do
+          expect(dummy_class.new.convert_null_value('some_value', nil)).to eql('some_value')
+        end
+      end
+      context 'when a mapping is defined' do
+        it 'maps the value to nil' do
+          expect(dummy_class.new.convert_null_value('some_value', 'some_value')).to eql(nil)
+        end
+      end
+    end
+
+    describe '#values_match' do
+      context 'when no null mapping is defined' do
+        it 'always matches if there was no expectation' do
+          actual = 'some_value'
+          expected = nil
+          expect(dummy_class.new.values_match(actual, expected)).to eql(true)
+        end
+        it 'never matches if the actual value is null' do
+          actual = nil
+          expected = 'some_value'
+          expect(dummy_class.new.values_match(actual, expected)).to eql(false)
+        end
+      end
+      context 'when some null mapping is defined' do
+        it 'always matches if there was no expectation' do
+          actual = 'some_value'
+          expected = nil
+          expect(dummy_class.new.values_match(actual, expected, null='whatever')).to eql(true)
+        end
+        it 'matches the set null placeholder' do
+          actual = nil
+          expected = 'some_value'
+          null = 'some_value'
+          expect(dummy_class.new.values_match(actual, expected, null=null)).to eql(true)
+        end
+        it 'does not match if the null placeholder does not match' do
+          actual = nil
+          expected = 'some_value'
+          null = 'some_other_value'
+          expect(dummy_class.new.values_match(actual, expected, null)).to eql(false)
+        end
+      end
+    end
+
     describe '#convert_mock_values' do
       context 'with minute placeholders' do
         it 'sets minutes in the future' do


### PR DESCRIPTION
This PR introduces support for mapping a custom null value like this:
```gherkin
Given "FOO" as null value
And the existing table "some_schema.some_table":
  | some_column |
  | NULL        |
  | FOO         |
```
In the above case, `NULL` would be entered into the database as a string. In fact, this was always the case and one could only specify a column as truly `null` if it wasn't specified at all. This made for cumbersome test setups, especially when used with otherwise perfectly fine default values. Now, with `Given "FOO" as null value`, the string `FOO` would be mapped to a true `null` in the database. This is case sensitive.

The change is fully backwards compatible as a non-existent mapper won't cause any values to be modified.