### PR TITLE
Fix values being converted to null accidentally

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -48,6 +48,8 @@ module MatcherHelpers
       value
     elsif value.eql?(null)
       nil
+    else
+      value
     end
   end
 

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -17,8 +17,15 @@ module Squcumber
         end
       end
       context 'when a mapping is defined' do
-        it 'maps the value to nil' do
-          expect(dummy_class.new.convert_null_value('some_value', 'some_value')).to eql(nil)
+        context 'and the value matches the mapper' do
+          it 'maps the value to nil' do
+            expect(dummy_class.new.convert_null_value('some_value', 'some_value')).to eql(nil)
+          end
+        end
+        context 'and the value does not match the mapper' do
+          it 'maps the value to itself' do
+            expect(dummy_class.new.convert_null_value('some_value', 'some_other_value')).to eql('some_value')
+          end
         end
       end
     end


### PR DESCRIPTION
Introduced by #22 

Only affected users of version `0.1.3` who made use of the `Given "nullplaceholder" as null value` step on Oct 18.