### PR TITLE
Fix value matcher if null value does not match

### DIFF
--- a/lib/squcumber-postgres/support/matchers.rb
+++ b/lib/squcumber-postgres/support/matchers.rb
@@ -21,8 +21,8 @@ module MatcherHelpers
       actual.match(/^#{Regexp.quote(Date.today.to_s)} \d{2}:\d{2}:\d{2}$/)
     elsif expected.eql?('sometime yesterday')
       actual.match(/^#{Regexp.quote((Date.today - 1).to_s)} \d{2}:\d{2}:\d{2}$/)
-    elsif !null.nil? and !expected.nil?
-      expected.eql?(null) and actual.nil?
+    elsif !null.nil? and !expected.nil? and expected.eql?(null)
+      actual.nil?
     elsif expected.eql?('any_string')
       true if actual.is_a?(String) or actual.nil?
     elsif expected.eql?('false') or expected.eql?('true')

--- a/spec/squcumber-postgres/support/matchers_spec.rb
+++ b/spec/squcumber-postgres/support/matchers_spec.rb
@@ -61,6 +61,12 @@ module Squcumber
           null = 'some_other_value'
           expect(dummy_class.new.values_match(actual, expected, null)).to eql(false)
         end
+        it 'matches if the null placeholder does not match but the values do' do
+          actual = 'some_value'
+          expected = 'some_value'
+          null = 'some_other_value'
+          expect(dummy_class.new.values_match(actual, expected, null)).to eql(true)
+        end
       end
     end
 


### PR DESCRIPTION
Introduced by #22 

Only affected users of version `0.1.3` who made use of the `Given "nullplaceholder" as null value` step on Oct 18.